### PR TITLE
Better support for offline environments

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -316,8 +316,12 @@ var _ = Describe("BOSH Windows", func() {
 	})
 
 	It("has all certificate authority certs that are present on the Windows Update Server", func() {
-		err := runTest("check-wu-certs")
-		Expect(err).NotTo(HaveOccurred())
+		if config.SkipMSUpdateTest {
+			Skip("Skipping check-updates test - SkipMSUpdateTest set to true")
+		} else {
+			err := runTest("check-wu-certs")
+			Expect(err).NotTo(HaveOccurred())
+		}
 	})
 
 	It("mounts ephemeral disks when asked to do so and does not mount them otherwise", func() {


### PR DESCRIPTION
This PR fixes two issues that we ran into while running with the test suite in an offline environment:

1. The Go and LGPO packages cannot be downloaded.  The PR modifies the test suite to accept optional paths to those packages in the configuration.  The test suite will skip downloading the packages if the path is set in the configuration.

2. We don't have access to the update server in our offline environment.  This meant we cannot get the certificates from the Windows Update server.  We changed the suite to skip the check-wu-certs test when SkipMSUpdateTest is set to true.